### PR TITLE
Update Supervisely SDK to 6.73.564

### DIFF
--- a/config.json
+++ b/config.json
@@ -3,7 +3,7 @@
   "type": "app",
   "categories": ["import", "dicom", "essentials"],
   "description": "Import volumes in DICOM and NRRD formats without annotations",
-  "docker_image": "supervisely/import-export:6.73.534",
+  "docker_image": "supervisely/import-export:6.73.564",
   "main_script": "src/main.py",
   "modal_template": "src/modal.html",
   "modal_template_state": {

--- a/config.json
+++ b/config.json
@@ -20,7 +20,7 @@
   "poster": "https://github.com/supervisely-ecosystem/import-dicom-volumes/releases/download/v1.0.0/poster.png",
   "headless": true,
   "min_agent_version": "6.7.4",
-  "min_instance_version": "6.15.40",
+  "instance_version": "6.15.60",
   "context_menu": {
     "context_category": "Import",
     "target": [

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,2 +1,2 @@
-supervisely==6.73.407
+supervisely==6.73.564
 black==22.3.0


### PR DESCRIPTION
Updates default Supervisely Docker apps to Supervisely SDK `6.73.564`.

- Updates `docker_image` tags for default Supervisely images.
- Updates Supervisely SDK references in requirements and Dockerfiles.
- Does not release applications.

Validation: generated ecosystem inventory report.
